### PR TITLE
Added vertex functions to documentation.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,8 +15,8 @@ Jive = "0.3"
 julia = "1.6"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Jive = "ba5e3d4b-8524-549f-bc71-e76ad9e9deed"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "Jive"]

--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -67,6 +67,15 @@ originToDirectedEdges
 directedEdgeToBoundary
 ```
 
+# Vertex functions
+```@docs
+getNumVertexes
+cellToVertex
+cellToVertexes
+vertexToLatLng
+isValidVertex
+```
+
 # Miscellaneous H3 functions
 ```@docs
 cellAreaRads2


### PR DESCRIPTION
The `@param` parts are not displaying correctly in the added vertex documentation, but this seems to be true in the pre-existing documentation as well. I'll leave this as-is, for now. Let's fix this throughout all at once, when we can.